### PR TITLE
Upgrade Icons Syntax

### DIFF
--- a/admin-api-backend.mdx
+++ b/admin-api-backend.mdx
@@ -35,7 +35,7 @@ If you're unfamiliar with GraphQL, there's some excellent resources to help you 
 
 Don't worry if you're not entirely familiar though - we'll help you get setup with Kana no matter the case. Take a look at our Quick Start guide to get up-and-running using our GraphQL API with little effort.
 
-<Card title="Quick Start" icon={regular("circle-play")} href="/quick-start">
+<Card title="Quick Start" icon="circle-play" href="/quick-start">
   Get set up and provide simple example code to create something within Kana
 </Card>
 
@@ -45,7 +45,7 @@ You'll need to an API Key in order to utilise the GraphQL API. We have a handy g
 
 <Card
   title="Authorization (Backend)"
-  icon={regular("user-lock")}
+  icon="user-lock"
   href="/admin-api-backend/authorization-backend"
 />
 
@@ -55,7 +55,7 @@ Our GraphQL API Reference details the [schema](https://graphql.org/learn/schema/
 
 <Card
   title="Admin API (Backend) Reference"
-  icon={regular("rectangle-terminal")}
+  icon="rectangle-terminal"
   href="/reference/admin-api-backend-reference"
 />
 

--- a/client-sdk-frontend.mdx
+++ b/client-sdk-frontend.mdx
@@ -10,7 +10,7 @@ You'll need to fetch a `userToken` and provide this when initializing the Kana J
 
 <Card
   title="Authorization (Frontend)"
-  icon={regular("user-lock")}
+  icon="user-lock"
   href="/client-sdk-frontend/authorization-frontend"
 />
 
@@ -20,6 +20,6 @@ Our Javascript SDK Reference details all available [methods](/reference/client-s
 
 <Card
   title="Client SDK (Frontend) Reference"
-  icon={regular("toolbox")}
+  icon="toolbox"
   href="/reference/client-sdk-frontend-reference"
 />

--- a/client-sdk-frontend/authorization-frontend.mdx
+++ b/client-sdk-frontend/authorization-frontend.mdx
@@ -21,12 +21,12 @@ Here's guides on how to achieve each:
 
 <Card
   title="Simple Mode"
-  icon={regular("circle-play")}
+  icon="circle-play"
   href="/client-sdk-frontend/authorization-frontend/simple-mode"
 />
 
 <Card
   title="Secure Mode"
-  icon={regular("shield-keyhole")}
+  icon="shield-keyhole"
   href="/client-sdk-frontend/authorization-frontend/secure-mode"
 />

--- a/guides.mdx
+++ b/guides.mdx
@@ -6,8 +6,8 @@ description: "Now you know the basics of Kana, we can start by helping you setup
 ## Choose your language
 
 <CardGroup cols={2}>
-  <Card title="Javascript" icon={brands("js")} href="/guides/javascript"></Card>
-  <Card title="Ruby" icon={regular("gem")} href="/guides/ruby"></Card>
+  <Card title="Javascript" icon="js" href="/guides/javascript"></Card>
+  <Card title="Ruby" icon="gem" href="/guides/ruby"></Card>
 </CardGroup>
 
 <Tip>

--- a/guides/javascript.mdx
+++ b/guides/javascript.mdx
@@ -6,23 +6,19 @@ title: "Overview"
 
 Before we get started, you're going to want to ensure you have successfully installed all required libraries and have initialized them correctly to make successful calls.
 
-<Card
-  title="Setup"
-  icon={regular("screwdriver-wrench")}
-  href="/guides/javascript/setup"
-/>
+<Card title="Setup" icon="screwdriver-wrench" href="/guides/javascript/setup" />
 
 You'll also need to ensure that you have setup all your features and packages within the [Kana Dashboard](https://dashboard.usekana.com). You can see more on these concepts within the [Kana Concepts](/kana-concepts) page, and more on how to create features and packages through the following guides.
 
 <Card
   title="Create Features"
-  icon={regular("star")}
+  icon="star"
   href="/guides/ruby/importing-and-creating/create-features"
 />
 
 <Card
   title="Create Packages"
-  icon={regular("box-taped")}
+  icon="box-taped"
   href="/guides/ruby/importing-and-creating/create-packages"
 />
 
@@ -32,7 +28,7 @@ You can then start thinking about bringing the users of your product into Kana s
 
 <Card
   title="Create Users"
-  icon={regular("user-plus")}
+  icon="user-plus"
   href="/guides/ruby/importing-and-creating/create-users"
 />
 
@@ -55,19 +51,19 @@ The following guides will allow you to start integrating some of these vital flo
 
 <Card
   title="Record Feature Usage"
-  icon={regular("video")}
+  icon="video"
   href="/guides/ruby/integrating-kana/record-feature-usage"
 />
 
 <Card
   title="Block Feature Access (Backend)"
-  icon={regular("user-lock")}
+  icon="user-lock"
   href="/guides/javascript/block-feature-access-backend"
 />
 
 <Card
   title="Block Feature Access (Frontend)"
-  icon={regular("user-lock")}
+  icon="user-lock"
   href="/guides/javascript/block-feature-access-frontend"
 />
 

--- a/guides/javascript/setup.mdx
+++ b/guides/javascript/setup.mdx
@@ -88,13 +88,13 @@ You'll want to ensure first that you have created all your features and packages
 
 <Card
   title="Create new features"
-  icon={regular("star")}
+  icon="star"
   href="/non-technical/features/create-new-features"
 />
 
 <Card
   title="Create new packages"
-  icon={regular("box-taped")}
+  icon="box-taped"
   href="/non-technical/packages/create-new-packages"
 />
 
@@ -102,6 +102,6 @@ Once that's done, it's integration time! You'll need to start by importing exist
 
 <Card
   title="Create Users"
-  icon={regular("user-plus")}
+  icon="user-plus"
   href="/guides/javascript/create-users"
 />

--- a/guides/ruby.mdx
+++ b/guides/ruby.mdx
@@ -6,11 +6,7 @@ title: "Overview"
 
 Before we get started, you're going to want to ensure you are successfully setup to send GraphQL requests in your language with relevant client libraries. You can find more on how to do this here:
 
-<Card
-  title="Setup"
-  icon={regular("screwdriver-wrench")}
-  href="/guides/ruby/setup"
-/>
+<Card title="Setup" icon="screwdriver-wrench" href="/guides/ruby/setup" />
 
 ## Importing & Creating
 
@@ -18,19 +14,19 @@ You can then begin to create and manage your packages (aka. plans) within Kana b
 
 <Card
   title="Create Features"
-  icon={regular("star")}
+  icon="star"
   href="/guides/ruby/importing-and-creating/create-features"
 />
 
 <Card
   title="Create Packages"
-  icon={regular("box-taped")}
+  icon="box-taped"
   href="/guides/ruby/importing-and-creating/create-packages"
 />
 
 <Card
   title="Create Users"
-  icon={regular("users")}
+  icon="users"
   href="/guides/ruby/importing-and-creating/create-users"
 />
 
@@ -40,19 +36,19 @@ Afterwards, you'll be ready to utilise Kana's functionality to manage your users
 
 <Card
   title="Subscribe Users to Plans"
-  icon={regular("square-dollar")}
+  icon="square-dollar"
   href="/guides/ruby/integrating-kana/subscribe-users-to-plans"
 />
 
 <Card
   title="Record Feature Usage"
-  icon={regular("video")}
+  icon="video"
   href="/guides/ruby/integrating-kana/record-feature-usage"
 />
 
 <Card
   title="Identify a User's Feature Entitlement"
-  icon={regular("shield-keyhole")}
+  icon="shield-keyhole"
   href="/guides/ruby/integrating-kana/identify-a-users-feature-entitlement"
 />
 

--- a/guides/ruby/importing-and-creating.mdx
+++ b/guides/ruby/importing-and-creating.mdx
@@ -7,13 +7,13 @@ If any features & plans were missed as part of this flow, or you want to add any
 
 <Card
   title="Create Features"
-  icon={regular("star")}
+  icon="star"
   href="/guides/ruby/importing-and-creating/create-features"
 />
 
 <Card
   title="Create Packages"
-  icon={regular("box-taped")}
+  icon="box-taped"
   href="/guides/ruby/importing-and-creating/create-packages"
 />
 
@@ -23,6 +23,6 @@ If you don't use Stripe, then you can create users through our GraphQL API in or
 
 <Card
   title="Create Users"
-  icon={regular("users")}
+  icon="users"
   href="/guides/ruby/importing-and-creating/create-users"
 />

--- a/guides/ruby/integrating-kana.mdx
+++ b/guides/ruby/integrating-kana.mdx
@@ -16,18 +16,18 @@ Here's all the related guides - although we recommend starting from the top down
 
 <Card
   title="Subscribe Users to Plans"
-  icon={regular("square-dollar")}
+  icon="square-dollar"
   href="/guides/ruby/integrating-kana/subscribe-users-to-plans"
 />
 
 <Card
   title="Record Feature Usage"
-  icon={regular("video")}
+  icon="video"
   href="/guides/ruby/integrating-kana/record-feature-usage"
 />
 
 <Card
   title="Identify a User's Feature Entitlement"
-  icon={regular("shield-keyhole")}
+  icon="shield-keyhole"
   href="/guides/ruby/integrating-kana/identify-a-users-feature-entitlement"
 />

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,7 +7,7 @@ description: "Kana provides developer tools for pricing and packaging. Build pow
 
 Let's get you saying **Hello World** in a matter of minutes. Jump in to the Quick Start docs and make your first request.
 
-<Card title="Quick Start" icon={regular("circle-play")} href="/quick-start">
+<Card title="Quick Start" icon="circle-play" href="/quick-start">
   Get set up and provide simple example code to create something within Kana
 </Card>
 
@@ -16,29 +16,21 @@ Let's get you saying **Hello World** in a matter of minutes. Jump in to the Quic
 Need some context on all things Kana? We have a handy guide to get you started in understanding our product and what's possible.
 
 <CardGroup cols={2}>
-<Card title="Kana Concepts" icon={regular('book-bookmark')} href="/kana-concepts">
+<Card title="Kana Concepts" icon="book-bookmark" href="/kana-concepts">
   Understand a few of the concepts that make up Kana
 </Card>
 
-<Card
-  title="Features"
-  icon={regular("list-check")}
-  href="/non-technical/features"
->
+<Card title="Features" icon="list-check" href="/non-technical/features">
   An overview on what features are and how they work
 </Card>
 
-<Card
-  title="Packages"
-  icon={regular("box-taped")}
-  href="/non-technical/packages"
->
+<Card title="Packages" icon="box-taped" href="/non-technical/packages">
   An overview on packages and how to add them
 </Card>
 
 <Card
   title="Stripe Integration"
-  icon={brands('stripe-s')}
+  icon='stripe-s'
   href="/non-technical/integrations/stripe-integration"
 >
   Learn how to connect Stripe with Kana
@@ -49,7 +41,7 @@ Need some context on all things Kana? We have a handy guide to get you started i
 
 Get a full walkthrough of setting up Kana with examples on how to integrate for the use-cases you want to achieve.
 
-<Card title="Guides" icon={regular("book-open-cover")} href="/guides">
+<Card title="Guides" icon="book-open-cover" href="/guides">
   How to setup and integrate Kana into your product
 </Card>
 
@@ -66,12 +58,12 @@ We're also actively working on building out SDKs in the languages which matter t
 <CardGroup cols={2}>
   <Card
     title="Admin API (Backend)"
-    icon={regular("rectangle-terminal")}
+    icon="rectangle-terminal"
     href="/admin-api-backend"
   />
   <Card
     title="Admin API (Backend) Reference"
-    icon={regular("rectangle-terminal")}
+    icon="rectangle-terminal"
     href="/reference/admin-api-backend-reference"
   />
 </CardGroup>
@@ -83,12 +75,12 @@ Our Client SDK is perfect for building out all read-only flows and components wh
 <CardGroup cols={2}>
   <Card
     title="Client SDK (Frontend)"
-    icon={regular("toolbox")}
+    icon="toolbox"
     href="/client-sdk-frontend"
   />
   <Card
     title="Client SDK (Frontend) Reference"
-    icon={regular("toolbox")}
+    icon="toolbox"
     href="/reference/client-sdk-frontend-reference"
   />
 </CardGroup>

--- a/quick-start.mdx
+++ b/quick-start.mdx
@@ -143,23 +143,19 @@ You just made a successful call to our GraphQL API and created your first user w
 
 You may now want to know a little more about what you just created within Kana, alongside some of the other concepts that make up the fabric of our product. If you're unfamiliar, then take a look at our Concepts guide:
 
-<Card
-  title="Kana Concepts"
-  icon={regular("book-bookmark")}
-  href="/kana-concepts"
->
+<Card title="Kana Concepts" icon="book-bookmark" href="/kana-concepts">
   Understand a few of the concepts that make up Kana
 </Card>
 
 If you're already in the know, then it's time to dive in deeper by setting up Kana and integrating it within your product. You can either follow our guided walkthrough, or jump straight into our API & SDK documentation:
 
-<Card title="Guides" icon={regular("book-open-cover")} href="/guides">
+<Card title="Guides" icon="book-open-cover" href="/guides">
   How to setup and integrate Kana into your product
 </Card>
 
 <Card
   title="Admin API (Backend)"
-  icon={regular("rectangle-terminal")}
+  icon="rectangle-terminal"
   href="/admin-api-backend"
 >
   How to use the Admin API


### PR DESCRIPTION
# Summary

We at Mintlify introduced an improved syntax for [adding icons](https://mintlify.com/docs/components/card). This PR updates the syntax for the current docs. Everything will look the same as before.

<img width="1552" alt="Screen Shot 2022-10-30 at 12 51 16 PM" src="https://user-images.githubusercontent.com/44352119/198898716-d133b0bc-c8b5-4ac6-bca0-8b6b8532d348.png">

### Updated Syntax

Before

```jsx
<Card
  icon={regular("name")}
/>
```

Now

```jsx
<Card
  icon="name"
/>
```

An optional `iconType` can be specified to define the type of the icon